### PR TITLE
Only hot load js files

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,13 @@ module.exports = function(file, opts) {
       inputMap = inputMapCV.toObject();
       source = convert.removeComments(source);
     }
+
+    // Only hot load js files
+    if (!/.js$/.test(file)) {
+      self.push(source)
+      return done()
+    }
+    
     reactHotLoader.call({
       resourcePath: file,
       callback: function(err, source, map) {


### PR DESCRIPTION
That's an hotfix because it's impossible to require `json` files at the moment and it's better than renaming json files to js and adding `export default`

```
/home/donnees/workspaces/react-hot-transform-test/test.json:1
module.exports=/* REACT HOT LOADER */ if (module.hot) { (function () { var ReactHotAPI = require("/home/donnees/workspaces/.smallmultiple/oeh/oeh-who-cares/frontend/node_modules/react-hot-api/modules/index.js"), RootInstanceProvider = require("/home/donnees/workspaces/.smallmultiple/oeh/oeh-who-cares/frontend/node_modules/react-hot-loader/RootInstanceProvider.js"), ReactMount = require("react/lib/ReactMount"), React = require("react"); module.makeHot = module.hot.data ? module.hot.data.makeHot : ReactHotAPI(function () { return RootInstanceProvider.getRootInstances(ReactMount); }, React); })(); } try { (function () {
                                      ^
ParseError: Unexpected token
```
